### PR TITLE
Dedupe duplicate player rows and names; sort displays; add value fallback and tests

### DIFF
--- a/app/edge_tab.py
+++ b/app/edge_tab.py
@@ -963,19 +963,50 @@ def render_edge_tab(sport: str) -> None:
         _display_fades = {f.get("player_name", "") for f in edge_analysis["fade_candidates"]}
         _display_fades.discard("")
 
+    def _dedupe_players(players: list[dict]) -> list[dict]:
+        out: list[dict] = []
+        seen: set[str] = set()
+        for p in players or []:
+            _name = p.get("player_name", "")
+            if not _name or _name in seen:
+                continue
+            out.append(p)
+            seen.add(_name)
+        return out
+
     def _strip_fades(players: list, fades: set) -> list:
-        return [p for p in players if p.get("player_name", "") not in fades]
+        cleaned = _dedupe_players(players)
+        return [p for p in cleaned if p.get("player_name", "") not in fades]
 
     col1, col2, col3 = st.columns(3)
     with col1:
-        _render_edge_box("core_plays", _strip_fades(edge_analysis.get("core_plays", []), _display_fades), is_pga, _cleared)
+        _core = sorted(
+            _strip_fades(edge_analysis.get("core_plays", []), _display_fades),
+            key=lambda p: float(p.get("proj", 0) or 0),
+            reverse=True,
+        )
+        _render_edge_box("core_plays", _core, is_pga, _cleared)
     with col2:
-        _render_edge_box("leverage_plays", _strip_fades(edge_analysis.get("leverage_plays", []), _display_fades), is_pga, _cleared)
+        _lev = sorted(
+            _strip_fades(edge_analysis.get("leverage_plays", []), _display_fades),
+            key=lambda p: float(p.get("edge", 0) or 0),
+            reverse=True,
+        )
+        _render_edge_box("leverage_plays", _lev, is_pga, _cleared)
     with col3:
-        _render_edge_box("value_plays", _strip_fades(edge_analysis.get("value_plays", []), _display_fades), is_pga, _cleared)
+        _val = sorted(
+            _strip_fades(edge_analysis.get("value_plays", []), _display_fades),
+            key=lambda p: float(p.get("value", 0) or 0),
+            reverse=True,
+        )
+        _render_edge_box("value_plays", _val, is_pga, _cleared)
 
     # ── Fade candidates with per-player reasoning ──────────────────────────
-    _all_fades = edge_analysis.get("fade_candidates", [])
+    _all_fades = sorted(
+        _dedupe_players(edge_analysis.get("fade_candidates", [])),
+        key=lambda p: float(p.get("fade_score", 0) or 0),
+        reverse=True,
+    )
     if _all_fades:
         st.markdown("---")
         st.markdown("#### 🚫 Fade Candidates")

--- a/tests/test_edge_scoring.py
+++ b/tests/test_edge_scoring.py
@@ -307,3 +307,27 @@ class TestClassifyPlays:
         classified = classify_plays(pd.DataFrame(), sport="NBA")
         for key in ("core_plays", "leverage_plays", "value_plays", "fade_candidates"):
             assert classified[key] == [], f"Expected empty list for {key}"
+
+    def test_duplicate_player_rows_do_not_duplicate_output_names(self):
+        pool = _make_pool(12)
+        dup = pool.iloc[[0]].copy()
+        dup["proj"] = dup["proj"] + 5.0  # ensure deterministic "keep highest proj"
+        pool = pd.concat([pool, dup], ignore_index=True)
+
+        classified = classify_plays(pool, sport="NBA")
+        all_names: list[str] = []
+        for key in ("core_plays", "leverage_plays", "value_plays", "fade_candidates"):
+            all_names.extend(p["player_name"] for p in classified[key])
+        assert len(all_names) == len(set(all_names)), "Duplicate player leaked into output buckets"
+
+    def test_value_fallback_populates_when_low_risk_filter_is_empty(self):
+        # Missing risk inputs -> risk_score all zeros -> _low_risk mask empty (0 < p80(0) is false)
+        # Fallback should still populate value plays from sub-$7k pool.
+        pool = pd.DataFrame([
+            {"player_name": "A", "salary": 6200, "proj": 29.0, "ownership": 8.0, "ceil": 40.0, "sim90th": 41.0},
+            {"player_name": "B", "salary": 6400, "proj": 28.0, "ownership": 9.0, "ceil": 39.0, "sim90th": 40.0},
+            {"player_name": "C", "salary": 6800, "proj": 30.0, "ownership": 10.0, "ceil": 42.0, "sim90th": 43.0},
+            {"player_name": "D", "salary": 7200, "proj": 34.0, "ownership": 11.0, "ceil": 46.0, "sim90th": 47.0},
+        ])
+        classified = classify_plays(pool, sport="NBA")
+        assert classified["value_plays"], "Expected non-empty value_plays via fallback path"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -298,6 +298,17 @@ class TestNormalizeEdgeAnalysis:
         _, errors = normalize_edge_analysis(ea, sport="PGA")
         assert any("PGA" in e for e in errors)
 
+    def test_duplicate_names_in_section_are_deduped(self):
+        ea = {
+            "fade_candidates": [
+                {"player_name": "Dup", "salary": 7000, "proj": 30.0},
+                {"player_name": "Dup", "salary": 7100, "proj": 31.0},
+            ]
+        }
+        out, errors = normalize_edge_analysis(ea, sport="NBA")
+        assert len(out["fade_candidates"]) == 1
+        assert any("duplicate 'Dup'" in e for e in errors)
+
 
 # ---------------------------------------------------------------------------
 # EdgePlay dataclass

--- a/yak_core/edge_scoring.py
+++ b/yak_core/edge_scoring.py
@@ -247,6 +247,16 @@ def classify_plays(sdf: pd.DataFrame, sport: str = "NBA") -> dict:
         return pd.Series(default, index=frame.index)
 
     df = sdf.copy()
+    # Guard against duplicate rows leaking in from upstream merges (e.g. RG +
+    # model blends). Keep the strongest projection per player.
+    if "player_name" in df.columns and df["player_name"].duplicated().any():
+        _before = len(df)
+        df = (
+            df.sort_values(by="proj", ascending=False, na_position="last")
+              .drop_duplicates(subset=["player_name"], keep="first")
+              .reset_index(drop=True)
+        )
+        print(f"[classify_plays] deduped players: {_before} -> {len(df)}")
     _sal  = _safe_col(df, "salary")
     _proj = _safe_col(df, "proj")
     _own_col = (
@@ -345,6 +355,9 @@ def classify_plays(sdf: pd.DataFrame, sport: str = "NBA") -> dict:
 
     # ── Value (Salary Savers): best pts/$1K under $6.5K ───────────────────
     _val_pool = df[(df["_sal"] < 6500) & (df["_sal"] > 0) & _low_risk & ~df["player_name"].isin(_used)]
+    # Fallback: when risk filter is too strict, still show value leaders.
+    if _val_pool.empty:
+        _val_pool = df[(df["_sal"] < 7000) & (df["_sal"] > 0) & ~df["player_name"].isin(_used)]
     value     = _val_pool.nlargest(5, "_val")
     _used.update(value["player_name"].tolist())
 
@@ -411,10 +424,12 @@ def classify_plays(sdf: pd.DataFrame, sport: str = "NBA") -> dict:
     for _af in _algo_fades:
         if len(_final_fades) >= MAX_FADE_CANDIDATES:
             break
-        if _af.get("player_name", "") not in _seen_names:
+        _name = _af.get("player_name", "")
+        if _name not in _seen_names:
             _af = dict(_af)
             _af.setdefault("own_pct", _af.get("ownership", 0))
             _final_fades.append(_af)
+            _seen_names.add(_name)
 
     return {
         "core_plays":      _to_list(core,     tag="core"),

--- a/yak_core/schema.py
+++ b/yak_core/schema.py
@@ -451,6 +451,7 @@ def normalize_edge_analysis(
             continue
 
         clean_plays: List[Dict[str, Any]] = []
+        seen_names: set[str] = set()
         for i, play in enumerate(plays):
             if not isinstance(play, dict):
                 all_errors.append(
@@ -472,6 +473,12 @@ def normalize_edge_analysis(
             if not rec.get("player_name"):
                 # Skip plays with no name — they crash the render
                 continue
+            if rec["player_name"] in seen_names:
+                all_errors.append(
+                    f"[{sport}] {section}[{i}]: duplicate '{rec['player_name']}', dropping duplicate"
+                )
+                continue
+            seen_names.add(rec["player_name"])
 
             # Coerce numeric edge-play fields
             for col in ("salary", "proj", "ownership", "edge"):


### PR DESCRIPTION
### Motivation
- Prevent duplicate player entries leaking into UI and analysis when upstream merges or duplicate rows occur. 
- Ensure edge buckets are presented consistently (sorted) and that value plays show reasonable fallbacks when risk filters are empty. 
- Surface and drop duplicate named plays at normalization time and record readable errors for producers.

### Description
- Add row-level deduping in `classify_plays` to keep the highest `proj` per `player_name` and log a short message. 
- Add dedupe-on-name logic to `normalize_edge_analysis` to drop duplicate entries per section and append human-readable errors. 
- Prevent duplicate player names in the Streamlit UI by introducing `_dedupe_players` and applying it before filtering fades, and sort `core`, `leverage`, and `value` buckets by `proj`, `edge`, and `value` respectively. 
- Add a fallback in `classify_plays` so `value_plays` is populated from sub-$7k players when the low-risk filter yields an empty set. 
- Ensure algorithmic fades are appended without duplication by tracking `_seen_names` and add bookkeeping to propagate `own_pct` and other fields for final fades.
- Update tests to cover duplicate-row deduping, value fallback behavior, and duplicate-name dedupe in normalization (`tests/test_edge_scoring.py` and `tests/test_schema.py`).

### Testing
- Ran the unit test suite including the new tests in `tests/test_edge_scoring.py::TestClassifyPlays` and `tests/test_schema.py::TestNormalizeEdgeAnalysis`, all of which passed. 
- Verified `test_duplicate_player_rows_do_not_duplicate_output_names` and `test_value_fallback_populates_when_low_risk_filter_is_empty` succeeded against `classify_plays`. 
- Verified `test_duplicate_names_in_section_are_deduped` succeeded against `normalize_edge_analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf13ed790832cbbe6de62be3e13e8)